### PR TITLE
Add PowerPress Metadata

### DIFF
--- a/podcast.ini
+++ b/podcast.ini
@@ -46,6 +46,8 @@ performer="Mr. Smith, Mr. Jones"
 title=My first podcast
 tracknumber=0
 website=http://www.yourpodcast.org/
+# either 'episodic' or 'serial'
+podcast_type=episodic
 
 [links]
 telegram=http://www.yourpodcast.org/telegram
@@ -57,9 +59,11 @@ reddit=https://www.reddit.com/r/YourPodcast/
 [wordpress]
 skip=False
 xmlrpc=https://yourpodcast.wordpress.com/xmlrpc.php
+# uploaded files path: {0} is season number, {1} is episode number, {2} is mp3 filename
+# example for Ubuntu Podcast: "http://static.ubuntupodcast.org/ubuntupodcast/s{0}/e{1}/{2}"
+uploads_url="https://yourpodcast.wordpress.com/wp-content/uploads/yourpodcast/season{0}/episode{1}/{2}"
 username=yourusername
 password="yourpassword"
-status=publish
 title=My first podcast
 category=Season 1
 comment_status=open

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,7 @@ pysftp==0.2.8
 python-resize-image==1.1.3
 python-utils==2.0.0
 python-wordpress-xmlrpc==2.3
+phpserialize==1.3
 rsa==3.4.2
 simplejson==3.8.2
 six==1.10.0


### PR DESCRIPTION
New Python modules:
- phpserialize

New Configuration parameters:
- wordpress.uploads_url: replaces hardcoded ubuntupodcast MP3 URLs and original fallback code with a single configurable string. An example for the Ubuntu Podcast is included.
- tags.podcast_type: the type of podcast for inclusion into the PowerPress metadata. Can be either 'episodic' or 'serial'.

Fixes: #2 
Fixes: #1